### PR TITLE
ACM-ICPC: 화성탐사

### DIFF
--- a/junkyu/화성탐사.py
+++ b/junkyu/화성탐사.py
@@ -1,0 +1,39 @@
+import sys
+from heapq import heappop, heappush
+
+sys.stdin = open('input.txt')
+
+dx = [0, 1, 0, -1]
+dy = [1, 0, -1, 0]
+
+def bfs():
+    global q, graph, mapping
+
+    while q:
+        x, y, dist = heappop(q)
+
+        if mapping[x][y] < dist:
+            continue
+
+        for i in range(4):
+            nx, ny = x + dx[i], y + dy[i]
+            if 0 <= nx < N and 0 <= ny < N:
+                cost = dist + graph[nx][ny]
+                if cost < mapping[nx][ny]:
+                    mapping[nx][ny] = cost
+                    heappush(q, (nx, ny, cost))
+
+T = int(input())
+
+for t in range(1, T+1):
+    N = int(input())
+    INF = int(1e9)
+    graph = [list(map(int, input().split())) for _ in range(N)]
+    mapping = [[INF]*N for _ in range(N)]
+    q = []
+    heappush(q, (0, 0, graph[0][0]))
+    bfs()
+    print(mapping[N-1][N-1])
+
+
+


### PR DESCRIPTION
- **문제 사이트** : 
  - [ ] 백준
  - [ ] Programmers
  - [ ] SWEA
  - [x] ACM-ICPC

- **난이도**:
  - S2 정도?(개인적인 느낌입니다)

- **사용한 알고리즘**
  - 다익스트라 + BFS

- **어려웠던 점**:
  - 다익스트라를 BFS에 녹이는 과정이 조금 힘들었네요.
  - 단순히 그래프에서 녹이는 것이 아니라 델타이동이 껴있어서 이를 반영하기 위한 과정이 헷갈렸습니다
  - 그래도 큰 범주에는 벗어나지 않고 논리적인 흐름은 명확합니다.

- **Reference** :
  - '이것이 코딩테스트다(나동빈 저)
  - SWEA 문제 형식과 매우 유사합니다.

- **etc**:
  - 문제를 풀로 올립니다.

**화성탐사** 풀이시간: 40분 | 메모리 제한: 128MB(pop(0)와 같이 단순 BFS로 푸시면 시간 초과난다고 보시면 될거 같습니다.) | 기출: ACM-ICPC
당신은 화성 탐사 기계를 개발하는 프로그래머입니다. 그런데 화성은 에너지 공급원을 찾기가 힘듭니다. 그래서 에너지를 효율적으로 사용하고자 화성 탐사 기계가 출발 지점에서 목표 지점까지 이동할 때 항상 최적의 경로를 찾도록 개발해야 합니다.
화성 탐사 기계가 존재하는 공간은 N × N 크기의 2차원 공간이며, 각각의 칸을 지나기 위한 비용(에너지 소모량)이 존재합니다. 가장 왼쪽 위 칸인 [0][0] 위치에서 가장 오른쪽 칸인 [N-1][N-1]위치로 이동하는 최소 비용을 출력한느 프로그램을 작성하세요.  화성 탐사 기계는 특정한 위치에서 상하좌우 인접한 곳으로 1칸씩 이동할 수 있습니다.

**입력 조건**
- 첫째 줄에 테스트 케이스의 수 T(1 ⩽ T ⩽ 10)가 주어집니다.
- 매 테스트 케이스의 첫째 줄에는 탐사 공간의 크기를 의미하는 정수 N이 주어집니다. (2 ⩽ N ⩽ 125) 이어서 N개의 줄에 걸처 각 칸의 비용이 주어지며 공백으로 구분합니다. ( 0 ⩽ 각 칸의 비용 ⩽ 9)

**출력 조건**
- 각 테스트 케이스마다 [0][0]의 위치에서 [N-1][N-1]의 위치로 이동하는 최소 비용을 한 줄에 하나씩 출력합니다.

```
입력값

3 // 테스트 케이스 수
3 // 1번째 테스트 케이스의 N의 값
5 5 4
3 9 1
3 2 7
5
3 7 2 0 1
2 8 0 9 1
1 2 1 8 1
9 8 9 2 0
3 6 5 1 5
7
9 0 5 1 1 5 3
4 1 2 1 6 5 3
0 7 6 1 6 8 5
1 1 7 8 3 2 3
9 4 0 7 6 4 1
5 8 3 2 4 8 3
7 4 8 4 8 3 4
```
```
출력값

20
19
36
```